### PR TITLE
Introduce `respond_with` to Hanami::Action to easily respond to multiple formats

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,4 @@
+--no-private
+--markup markdown
+--markup-provider kramdown
+--quiet

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
+gem "bigdecimal", require: false, platforms: :mri
+
 group :tools do
   gem "debug"
 end

--- a/README.md
+++ b/README.md
@@ -28,6 +28,66 @@ That's all for now, you'll have access to the Core Extensions listed below throu
 
 ## Features:
 
+### Hanami Action
+
+We patch Hanami::Action in your Hanami applications to give a Developer Experience that will feel familiar for users of certian train themed frameworks in Ruby.
+
+#### Important Note on format support
+
+If you wish to use specific formats in the respond_to block, your config and `Hanami::Action` base action will likely need to define them to keep things clean.
+
+For example in `app/action.rb` add, then all children classes of AppName::Action will opt-in for the formats.
+
+```rb
+    format :html, :json, :md, :xml
+```
+
+For markdown support you'll need to add to the `config/app.rb` class
+
+```rb
+config.actions.formats.add(:md, "text/markdown")
+```
+
+You'll also need to define route formats for the endpoint to opt into it.
+
+```rb
+get "/books(.:format)", to: "books.index"
+```
+
+for example to allow any format to be passed through to the Action.
+
+#### respond_with
+
+Allows creating a `respond_with` block that is provided a format argument with `format.html` or `json`, `md`, or `xml` that can return a response body / render a view for the response. Currently only `html`, `json`, `md` and `xml` are supported, and cannot be extended. If you've got a format you'd love support for, please PR it and we can discuss.
+
+Hanami Omakase automatically handles setting the format / content type for you per the format specified in the block, as well as passing it through the `render` method on the `response`.
+
+**Note:** If you use `json` or `xml` formats, `layout` passed to `response.render` is automatically set to `nil`, but if you need to specify a layout you can pass the layout name `layout: "app"` to the `render(view, layout: "app")` call.
+
+If you need to return a specific response body for a format you have access to the response object just like in regular Hanami.
+
+`render` inside of a `format` block is a short-hand syntax for `response.render` so all regular Hanami `response.render` call options will work as before.
+
+```rb
+module Playground
+  module Actions
+    module Articles
+      class Index < Playground::Action
+        def handle(request, response)
+          page_param = (request.params[:page] || 1).to_i
+
+          respond_with do |format|
+            format.html { render(view, per_page: 10, page: page_param) }
+            format.json { render(view, per_page: 100, page: page_param) }
+            format.md { response.body = "# Hello world" }
+          end
+        end
+      end
+    end
+  end
+end
+```
+
 ### Core Extensions
 
 #### Integer

--- a/hanami-omakase.gemspec
+++ b/hanami-omakase.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_runtime_dependency "hanami", ">= 2.2"
+  spec.add_runtime_dependency "hanami-utils", ">= 2.2"
+  spec.add_runtime_dependency "hanami-controller", ">= 2.2"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec"

--- a/lib/hanami/omakase.rb
+++ b/lib/hanami/omakase.rb
@@ -3,6 +3,7 @@
 require "zeitwerk"
 
 require "hanami/omakase/utils"
+require "hanami/omakase/action"
 
 module Hanami
   module Omakase

--- a/lib/hanami/omakase/action.rb
+++ b/lib/hanami/omakase/action.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "hanami/action"
+
+module Hanami
+  module Omakase
+    # Exception raised when a requested format is not handled by the action
+    class UnknownFormatError < StandardError
+      def initialize(format, defined_formats)
+        super("Format '#{format}' is not supported. Defined formats: #{defined_formats.join(', ')}")
+      end
+    end
+
+    module Action
+      # Spec out support for Hanami::Action in the def handle(request, response) method
+      # to be able to respond to multiple formats easily.
+      #
+      # Inspired by the `respond_to` method in Rails controllers.
+      #
+      # Supported formats: :html, :json, :xml, :md
+      #
+      # Raises Hanami::Omakase::UnknownFormatError if the requested format is not handled.
+      #
+      # Usage:
+      #   class MyAction
+      #     include Hanami::Action
+      #
+      #     def handle(request, response)
+      #       respond_with do |format|
+      #         format.html { response.body = "<h1>Hello, HTML!</h1>" }
+      #         format.json { response.body = { message: "Hello, JSON!" }.to_json }
+      #         format.xml  { response.body = "<message>Hello, XML!</message>" }
+      #       end
+      #     end
+      #   end
+      def respond_with(&block)
+        req, res = extract_request_response(block.binding)
+        responder = FormatResponder.new(req, res)
+        yield responder
+        responder.validate_format_handled!
+      end
+
+      private
+
+      def extract_request_response(binding)
+        local_vars = binding.local_variables
+
+        req = local_vars.length >= 1 ? binding.local_variable_get(local_vars[0]) : nil
+        res = local_vars.length >= 2 ? binding.local_variable_get(local_vars[1]) : nil
+
+        # Fallback to instance methods if available
+        req ||= (respond_to?(:request, true) ? request : nil)
+        res ||= (respond_to?(:response, true) ? response : nil)
+
+        [req, res]
+      end
+
+      class FormatResponder
+        SUPPORTED_FORMATS = %w[html json xml md].freeze
+
+        CONTENT_TYPES = {
+          html: "text/html",
+          json: "application/json",
+          xml: "application/xml",
+          md: "text/markdown"
+        }.freeze
+
+        def initialize(request, response)
+          @request = request
+          @response = response
+          @content_type = nil
+          @defined_formats = []
+        end
+
+        SUPPORTED_FORMATS.each do |format|
+          define_method(format) do |&block|
+            @defined_formats << format.to_sym
+            respond_to_format(format.to_sym, &block)
+          end
+        end
+
+        def validate_format_handled!
+          requested_format = content_type
+          return if @defined_formats.include?(requested_format)
+
+          raise UnknownFormatError.new(requested_format, @defined_formats)
+        end
+
+        private
+
+        def respond_to_format(format, &block)
+          return unless content_type == format && block_given?
+
+          set_response_format(format)
+          block.call
+        end
+
+        def set_response_format(format)
+          return unless @response
+
+          @response.format = format
+
+          content_type_header = CONTENT_TYPES[format]
+          @response.headers["Content-Type"] = content_type_header if content_type_header
+        end
+
+        def content_type
+          @content_type ||= determine_content_type
+        end
+
+        def determine_content_type
+          return :html unless @request
+
+          # Check format parameter first (most explicit)
+          format_from_params || format_from_path_extension || format_from_accept_header
+        end
+
+        def format_from_params
+          return unless @request.respond_to?(:params) && @request.params
+
+          format_param = @request.params[:format]
+          return unless format_param && SUPPORTED_FORMATS.include?(format_param.to_s)
+
+          format_param.to_s.to_sym
+        end
+
+        def format_from_path_extension
+          path_info = @request.get_header("PATH_INFO")
+          return unless path_info&.include?(".")
+
+          ext = File.extname(path_info).delete_prefix(".")
+          return unless SUPPORTED_FORMATS.include?(ext)
+
+          ext.to_sym
+        end
+
+        def format_from_accept_header
+          accept_header = @request.get_header("HTTP_ACCEPT")
+          return unless accept_header
+
+          accept_types = parse_accept_header(accept_header)
+          determine_format_from_accept_types(accept_types)
+        end
+
+        def parse_accept_header(accept_header)
+          accept_header.split(",").map do |type|
+            parts = type.strip.split(";")
+            media_type = parts[0].strip
+            quality = extract_quality(parts)
+
+            {type: media_type, quality: quality}
+          end.sort_by { |t| -t[:quality] }
+        end
+
+        def extract_quality(parts)
+          quality_part = parts.find { |p| p.strip.start_with?("q=") }
+          return 1.0 unless quality_part
+
+          quality_part.split("=")[1].to_f
+        rescue StandardError
+          1.0
+        end
+
+        def determine_format_from_accept_types(accept_types)
+          # Check for specific JSON request (high priority)
+          json_type = accept_types.find { |t| t[:type] == "application/json" }
+          return :json if json_type && json_type[:quality] > 0.5
+
+          # For HTML vs XML conflict, prefer HTML unless XML has significantly higher quality
+          html_type = accept_types.find { |t| t[:type] == "text/html" }
+          xml_type = accept_types.find { |t| t[:type] == "application/xml" || t[:type] == "text/xml" }
+
+          if html_type && xml_type
+            xml_type[:quality] > html_type[:quality] + 0.1 ? :xml : :html
+          elsif html_type
+            :html
+          elsif xml_type && xml_type[:quality] > 0.5
+            :xml
+          end
+        end
+      end
+    end
+  end
+end
+
+# Automatically include Omakase::Action functionality in all Hanami::Action classes
+if defined?(Hanami::Action)
+  Hanami::Action.include(Hanami::Omakase::Action)
+end

--- a/lib/hanami/omakase/action.rb
+++ b/lib/hanami/omakase/action.rb
@@ -203,5 +203,5 @@ end
 
 # Automatically include Omakase::Action functionality in all Hanami::Action classes
 if defined?(Hanami::Action)
-  Hanami::Action.include(Hanami::Omakase::Action)
+  Hanami::Action.include(Hanami::Omakase::Action) # :nodoc:
 end


### PR DESCRIPTION
Inspired by a certain train themed framework for Ruby... this models similar to `respond_to do |format|` in Rails, but in Hanami.

Resolves #5 

Undefined file extensions formats will raise a `Hanami::Omakase::UnknownFormatError` error that can be handled in the base Hanami::Action class for a given application/slice.

This overrides Hanami's default behavior:
- Looks at the format in the action and uses that or;
- Looks at the path info for a file extension
- Falls back to accept header

Allows devs to build a `respond_with` block for specifying the response body for a given format. Blocks with do/end or `{}` are allowed as always:

```ruby
# frozen_string_literal: true
module Bookshelf
  module Actions
    module Books
      class Index2 < Bookshelf::Action
        format :html, :json, :xml, :md

        def handle(request, response)
          message = "Hello from Books Index2 action!"

          respond_with do |format|
            format.json { response.body = { message: message }.to_json }

            format.xml  { response.body = "<message>#{message}</message>" }

            # format.md { response.body = "# #{message}" }

            format.html do
              response.render(
                view,
                page: request.params[:page] || 1,
                per_page: request.params[:per_page] || 5
              )
              # Or this works too:
              # response.body = "<h1>Hello, HTML!</h1>"
            end
          end
        end
      end
    end
  end
end
```

Devs are still responsible for setting the routes properly in the router:

```ruby
    get "/books-2(.:format)", to: "books.index2", as: :books_2
```

Applications are still responsible for adding support to Hanami for formats currently:

```ruby
 # config/app.rb
    config.actions.formats.add(:md, "text/markdown")
    config.actions.formats.add(:png, "image/png")
    config.actions.formats.add(:jpg, "image/jpeg")
```