### PR TITLE
Hanami Router improvements: Resource / Resources DSL

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,4 @@
+--no-private
+--markup markdown
+--markup-provider kramdown
+--quiet

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ eval_gemfile "Gemfile.devtools"
 
 gemspec
 
+gem "bigdecimal", require: false, platforms: :mri
+
 group :tools do
   gem "debug"
 end

--- a/hanami-omakase.gemspec
+++ b/hanami-omakase.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.1.0"
 
   spec.add_runtime_dependency "hanami", ">= 2.2"
+  spec.add_runtime_dependency "hanami-utils", ">= 2.2"
+  spec.add_runtime_dependency "hanami-controller", ">= 2.2"
   spec.add_runtime_dependency "zeitwerk", "~> 2.6"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rspec"

--- a/lib/hanami/omakase.rb
+++ b/lib/hanami/omakase.rb
@@ -4,6 +4,7 @@ require "zeitwerk"
 
 require "hanami/omakase/utils"
 require "hanami/omakase/action"
+require "hanami/omakase/routing"
 
 module Hanami
   module Omakase

--- a/lib/hanami/omakase.rb
+++ b/lib/hanami/omakase.rb
@@ -3,6 +3,7 @@
 require "zeitwerk"
 
 require "hanami/omakase/utils"
+require "hanami/omakase/action"
 
 module Hanami
   module Omakase

--- a/lib/hanami/omakase/action.rb
+++ b/lib/hanami/omakase/action.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require "hanami/action"
+
+module Hanami
+  module Omakase
+    # Exception raised when a requested format is not handled by the action
+    class UnknownFormatError < StandardError
+      def initialize(format, defined_formats)
+        super("Format '#{format}' is not supported. Defined formats: #{defined_formats.join(', ')}")
+      end
+    end
+
+    module Action
+      # Spec out support for Hanami::Action in the def handle(request, response) method
+      # to be able to respond to multiple formats easily.
+      #
+      # Inspired by the `respond_to` method in Rails controllers.
+      #
+      # Supported formats: :html, :json, :xml, :md
+      #
+      # Raises Hanami::Omakase::UnknownFormatError if the requested format is not handled.
+      #
+      # Usage:
+      #   class MyAction
+      #     include Hanami::Action
+      #
+      #     def handle(request, response)
+      #       respond_with do |format|
+      #         format.html { response.body = "<h1>Hello, HTML!</h1>" }
+      #         format.json { response.body = { message: "Hello, JSON!" }.to_json }
+      #         format.xml  { response.body = "<message>Hello, XML!</message>" }
+      #       end
+      #     end
+      #   end
+      def respond_with(&block)
+        req, res = extract_request_response(block.binding)
+        responder = FormatResponder.new(req, res)
+        yield responder
+        responder.validate_format_handled!
+      end
+
+      private
+
+      def extract_request_response(binding)
+        local_vars = binding.local_variables
+
+        req = local_vars.length >= 1 ? binding.local_variable_get(local_vars[0]) : nil
+        res = local_vars.length >= 2 ? binding.local_variable_get(local_vars[1]) : nil
+
+        # Fallback to instance methods if available
+        req ||= (respond_to?(:request, true) ? request : nil)
+        res ||= (respond_to?(:response, true) ? response : nil)
+
+        [req, res]
+      end
+
+      class FormatResponder
+        SUPPORTED_FORMATS = %w[html json xml md].freeze
+
+        CONTENT_TYPES = {
+          html: "text/html",
+          json: "application/json",
+          xml: "application/xml",
+          md: "text/markdown"
+        }.freeze
+
+        def initialize(request, response)
+          @request = request
+          @response = response
+          @content_type = nil
+          @defined_formats = []
+        end
+
+        SUPPORTED_FORMATS.each do |format|
+          define_method(format) do |&block|
+            @defined_formats << format.to_sym
+            respond_to_format(format.to_sym, &block)
+          end
+        end
+
+        def validate_format_handled!
+          requested_format = content_type
+          return if @defined_formats.include?(requested_format)
+
+          raise UnknownFormatError.new(requested_format, @defined_formats)
+        end
+
+        private
+
+        def respond_to_format(format, &block)
+          return unless content_type == format && block_given?
+
+          set_response_format(format)
+          block.call
+        end
+
+        def set_response_format(format)
+          return unless @response
+
+          @response.format = format
+
+          content_type_header = CONTENT_TYPES[format]
+          @response.headers["Content-Type"] = content_type_header if content_type_header
+        end
+
+        def content_type
+          @content_type ||= determine_content_type
+        end
+
+        def determine_content_type
+          return :html unless @request
+
+          # Check format parameter first (most explicit)
+          format_from_params || format_from_path_extension || format_from_accept_header
+        end
+
+        def format_from_params
+          return unless @request.respond_to?(:params) && @request.params
+
+          format_param = @request.params[:format]
+          return unless format_param && SUPPORTED_FORMATS.include?(format_param.to_s)
+
+          format_param.to_s.to_sym
+        end
+
+        def format_from_path_extension
+          path_info = @request.get_header("PATH_INFO")
+          return unless path_info&.include?(".")
+
+          ext = File.extname(path_info).delete_prefix(".")
+          return unless SUPPORTED_FORMATS.include?(ext)
+
+          ext.to_sym
+        end
+
+        def format_from_accept_header
+          accept_header = @request.get_header("HTTP_ACCEPT")
+          return unless accept_header
+
+          accept_types = parse_accept_header(accept_header)
+          determine_format_from_accept_types(accept_types)
+        end
+
+        def parse_accept_header(accept_header)
+          accept_header.split(",").map do |type|
+            parts = type.strip.split(";")
+            media_type = parts[0].strip
+            quality = extract_quality(parts)
+
+            {type: media_type, quality: quality}
+          end.sort_by { |t| -t[:quality] }
+        end
+
+        def extract_quality(parts)
+          quality_part = parts.find { |p| p.strip.start_with?("q=") }
+          return 1.0 unless quality_part
+
+          quality_part.split("=")[1].to_f
+        rescue StandardError
+          1.0
+        end
+
+        def determine_format_from_accept_types(accept_types)
+          # Check for specific JSON request (high priority)
+          json_type = accept_types.find { |t| t[:type] == "application/json" }
+          return :json if json_type && json_type[:quality] > 0.5
+
+          # For HTML vs XML conflict, prefer HTML unless XML has significantly higher quality
+          html_type = accept_types.find { |t| t[:type] == "text/html" }
+          xml_type = accept_types.find { |t| t[:type] == "application/xml" || t[:type] == "text/xml" }
+
+          if html_type && xml_type
+            xml_type[:quality] > html_type[:quality] + 0.1 ? :xml : :html
+          elsif html_type
+            :html
+          elsif xml_type && xml_type[:quality] > 0.5
+            :xml
+          end
+        end
+      end
+    end
+  end
+end
+
+# Automatically include Omakase::Action functionality in all Hanami::Action classes
+if defined?(Hanami::Action)
+  Hanami::Action.include(Hanami::Omakase::Action)
+end

--- a/lib/hanami/omakase/action.rb
+++ b/lib/hanami/omakase/action.rb
@@ -203,5 +203,5 @@ end
 
 # Automatically include Omakase::Action functionality in all Hanami::Action classes
 if defined?(Hanami::Action)
-  Hanami::Action.include(Hanami::Omakase::Action)
+  Hanami::Action.include(Hanami::Omakase::Action) # :nodoc:
 end

--- a/lib/hanami/omakase/routing.rb
+++ b/lib/hanami/omakase/routing.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require "hanami/routes"
+
+module Hanami
+  module Omakase
+    module Routing
+      # Resource-style resource routing for Hanami
+      #
+      # Provides `resource` and `resources` methods to generate RESTful routes
+      # for provided resource names, following common conventions.
+      #
+      # Usage:
+      #   class Routes < Hanami::Routes
+      #     include Hanami::Omakase::Routing
+      #
+      #     resources :users
+      #     resource :profile
+      #   end
+      #
+      # `resources :users` generates:
+      #   GET    /users          users.index
+      #   GET    /users/new      users.new
+      #   POST   /users          users.create
+      #   GET    /users/:id      users.show
+      #   GET    /users/:id/edit users.edit
+      #   PATCH  /users/:id      users.update
+      #   PUT    /users/:id      users.update
+      #   DELETE /users/:id      users.destroy
+      #
+      # `resource :profile` generates (singular, no index):
+      #   GET    /profile/new    profile.new
+      #   POST   /profile        profile.create
+      #   GET    /profile        profile.show
+      #   GET    /profile/edit   profile.edit
+      #   PATCH  /profile        profile.update
+      #   PUT    /profile        profile.update
+      #   DELETE /profile        profile.destroy
+
+      # Generate RESTful routes for a plural resource
+      # @param name [Symbol] The resource name (plural)
+      # @param options [Hash] Options for customizing the routes
+      # @option options [Array<Symbol>] :only Limit to specific actions
+      # @option options [Array<Symbol>] :except Exclude specific actions
+      # @option options [String] :controller Override the controller name
+      # @option options [String] :path Override the URL path
+      # @option options [String, Symbol] :as Override the route name prefix
+      def resources(name, **options, &block)
+        controller = options[:controller] || name.to_s
+        path = options[:path] || name.to_s
+        route_name = options[:as] || singularize(name.to_s)
+        actions = determine_actions(%i[index new create show edit update destroy], options)
+
+        # Index route
+        if actions.include?(:index)
+          get "/#{path}", to: "#{controller}.index", as: pluralize(route_name)
+        end
+
+        # New route
+        if actions.include?(:new)
+          get "/#{path}/new", to: "#{controller}.new", as: "new_#{route_name}"
+        end
+
+        # Create route
+        if actions.include?(:create)
+          post "/#{path}", to: "#{controller}.create", as: pluralize(route_name)
+        end
+
+        # Show route
+        if actions.include?(:show)
+          get "/#{path}/:id", to: "#{controller}.show", as: route_name
+        end
+
+        # Edit route
+        if actions.include?(:edit)
+          get "/#{path}/:id/edit", to: "#{controller}.edit", as: "edit_#{route_name}"
+        end
+
+        # Update routes
+        if actions.include?(:update)
+          patch "/#{path}/:id", to: "#{controller}.update", as: route_name
+          put "/#{path}/:id", to: "#{controller}.update", as: route_name
+        end
+
+        # Destroy route
+        if actions.include?(:destroy)
+          delete "/#{path}/:id", to: "#{controller}.destroy", as: route_name
+        end
+
+        # Handle nested resources if block given
+        if block_given?
+          nested_context = NestedResourceContext.new(self, path)
+          nested_context.instance_eval(&block)
+        end
+      end
+
+      # Generate RESTful routes for a singular resource
+      # @param name [Symbol] The resource name (singular)
+      # @param options [Hash] Options for customizing the routes
+      # @option options [Array<Symbol>] :only Limit to specific actions
+      # @option options [Array<Symbol>] :except Exclude specific actions
+      # @option options [String] :controller Override the controller name
+      # @option options [String] :path Override the URL path
+      # @option options [String, Symbol] :as Override the route name
+      def resource(name, **options, &block)
+        controller = options[:controller] || name.to_s
+        path = options[:path] || name.to_s
+        route_name = options[:as] || name.to_s
+        actions = determine_actions(%i[new create show edit update destroy], options)
+
+        # New route
+        if actions.include?(:new)
+          get "/#{path}/new", to: "#{controller}.new", as: "new_#{route_name}"
+        end
+
+        # Create route
+        if actions.include?(:create)
+          post "/#{path}", to: "#{controller}.create", as: route_name
+        end
+
+        # Show route
+        if actions.include?(:show)
+          get "/#{path}", to: "#{controller}.show", as: route_name
+        end
+
+        # Edit route
+        if actions.include?(:edit)
+          get "/#{path}/edit", to: "#{controller}.edit", as: "edit_#{route_name}"
+        end
+
+        # Update routes
+        if actions.include?(:update)
+          patch "/#{path}", to: "#{controller}.update", as: route_name
+          put "/#{path}", to: "#{controller}.update", as: route_name
+        end
+
+        # Destroy route
+        if actions.include?(:destroy)
+          delete "/#{path}", to: "#{controller}.destroy", as: route_name
+        end
+
+        # Handle nested resources if block given
+        if block_given?
+          nested_context = NestedResourceContext.new(self, path)
+          nested_context.instance_eval(&block)
+        end
+      end
+
+      private
+
+      def determine_actions(default_actions, options)
+        if options[:only]
+          Array(options[:only]) & default_actions
+        elsif options[:except]
+          default_actions - Array(options[:except])
+        else
+          default_actions
+        end
+      end
+
+      # Simple singularization - removes 's' from end
+      # For more complex cases, could integrate with inflection library
+      def singularize(word)
+        word.chomp("s")
+      end
+
+      # Simple pluralization - adds 's' to end
+      # For more complex cases, could integrate with inflection library
+      def pluralize(word)
+        word.end_with?("s") ? word : "#{word}s"
+      end
+
+      # Context for handling nested resources
+      class NestedResourceContext
+        def initialize(router, parent_path)
+          @router = router
+          @parent_path = parent_path
+        end
+
+        def resources(name, **options)
+          controller = options[:controller] || name.to_s
+          path = options[:path] || name.to_s
+          route_name = options[:as] || @router.send(:singularize, name.to_s)
+          parent_name = singular_parent_name
+          actions = @router.send(:determine_actions, %i[index new create show edit update destroy], options)
+
+          # Nested routes with parent ID
+          if actions.include?(:index)
+            @router.get "/#{@parent_path}/:#{parent_name}_id/#{path}", to: "#{controller}.index",
+                                                                       as: "#{parent_name}_#{@router.send(:pluralize, route_name)}"
+          end
+
+          if actions.include?(:new)
+            @router.get "/#{@parent_path}/:#{parent_name}_id/#{path}/new", to: "#{controller}.new",
+                                                                           as: "new_#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:create)
+            @router.post "/#{@parent_path}/:#{parent_name}_id/#{path}", to: "#{controller}.create",
+                                                                        as: "#{parent_name}_#{@router.send(:pluralize, route_name)}"
+          end
+
+          if actions.include?(:show)
+            @router.get "/#{@parent_path}/:#{parent_name}_id/#{path}/:id", to: "#{controller}.show",
+                                                                           as: "#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:edit)
+            @router.get "/#{@parent_path}/:#{parent_name}_id/#{path}/:id/edit", to: "#{controller}.edit",
+                                                                                as: "edit_#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:update)
+            @router.patch "/#{@parent_path}/:#{parent_name}_id/#{path}/:id", to: "#{controller}.update",
+                                                                             as: "#{parent_name}_#{route_name}"
+            @router.put "/#{@parent_path}/:#{parent_name}_id/#{path}/:id", to: "#{controller}.update",
+                                                                           as: "#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:destroy)
+            @router.delete "/#{@parent_path}/:#{parent_name}_id/#{path}/:id", to: "#{controller}.destroy",
+                                                                              as: "#{parent_name}_#{route_name}"
+          end
+        end
+
+        def resource(name, **options)
+          controller = options[:controller] || name.to_s
+          path = options[:path] || name.to_s
+          route_name = options[:as] || name.to_s
+          parent_name = singular_parent_name
+          actions = @router.send(:determine_actions, %i[new create show edit update destroy], options)
+
+          # Nested singular resource routes
+          if actions.include?(:new)
+            @router.get "/#{@parent_path}/:#{parent_name}_id/#{path}/new", to: "#{controller}.new",
+                                                                           as: "new_#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:create)
+            @router.post "/#{@parent_path}/:#{parent_name}_id/#{path}", to: "#{controller}.create",
+                                                                        as: "#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:show)
+            @router.get "/#{@parent_path}/:#{parent_name}_id/#{path}", to: "#{controller}.show",
+                                                                       as: "#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:edit)
+            @router.get "/#{@parent_path}/:#{parent_name}_id/#{path}/edit", to: "#{controller}.edit",
+                                                                            as: "edit_#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:update)
+            @router.patch "/#{@parent_path}/:#{parent_name}_id/#{path}", to: "#{controller}.update",
+                                                                         as: "#{parent_name}_#{route_name}"
+            @router.put "/#{@parent_path}/:#{parent_name}_id/#{path}", to: "#{controller}.update",
+                                                                       as: "#{parent_name}_#{route_name}"
+          end
+
+          if actions.include?(:destroy)
+            @router.delete "/#{@parent_path}/:#{parent_name}_id/#{path}", to: "#{controller}.destroy",
+                                                                          as: "#{parent_name}_#{route_name}"
+          end
+        end
+
+        private
+
+        def singular_parent_name
+          # Simple singularization - remove 's' from end
+          # For more complex cases, could integrate with inflection library
+          @parent_path.to_s.chomp("s")
+        end
+      end
+    end
+  end
+end
+
+# Auto-include the routing module in Hanami::Routes if it's available
+if defined?(Hanami::Routes)
+  Hanami::Router.prepend(Hanami::Omakase::Routing)
+end


### PR DESCRIPTION
Adds `resource` and `resources` DSL for the Hanami Router.

```
      #
      # Usage:
      #   class Routes < Hanami::Routes
      #     resources :users
      #     resource :profile
      #   end
      #
      # `resources :users` generates:
      #   GET    /users          users.index
      #   GET    /users/new      users.new
      #   POST   /users          users.create
      #   GET    /users/:id      users.show
      #   GET    /users/:id/edit users.edit
      #   PATCH  /users/:id      users.update
      #   PUT    /users/:id      users.update
      #   DELETE /users/:id      users.destroy
      #
      # `resource :profile` generates (singular, no index):
      #   GET    /profile/new    profile.new
      #   POST   /profile        profile.create
      #   GET    /profile        profile.show
      #   GET    /profile/edit   profile.edit
      #   PATCH  /profile        profile.update
      #   PUT    /profile        profile.update
      #   DELETE /profile        profile.destroy
```